### PR TITLE
Made JS for finding elements at the same x,y coords work when the

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ focuslibs = {
 
 setup(
     name='vision',
-    version='0.10.219',
+    version='0.10.220',
     packages=find_packages(),
 
     # This requires selenium

--- a/vision/visioninterpreter.py
+++ b/vision/visioninterpreter.py
@@ -2214,7 +2214,7 @@ class VisionInterpreter(object):
             scroll_parents = self.webdriver.execute_script("""
                 var parent = arguments[0].parentNode;
                 var parents = [];
-                while(parent !== null && parent.tagName.toLowerCase() !== 'body' && parent.tagName.toLowerCase() !== 'html'){
+                while(typeof(parent) !== 'undefined' && parent !== null && parent.tagName.toLowerCase() !== 'body' && parent.tagName.toLowerCase() !== 'html'){
                     if(
                     typeof(parent.scrollHeight) !== 'undefined' &&
                         typeof(parent.scrollWidth) !== 'undefined' &&


### PR DESCRIPTION
Made JS for finding elements at the same x,y coords work when the starting element has no parent node.
Egg version bump.

 Changes to be committed:
    modified:   setup.py
    modified:   vision/visioninterpreter.py
